### PR TITLE
feat: add wdi5 as test framework

### DIFF
--- a/generators/wdi5/index.js
+++ b/generators/wdi5/index.js
@@ -1,0 +1,96 @@
+const Generator = require("yeoman-generator");
+const fileaccess = require("../../helpers/fileaccess");
+
+module.exports = class extends Generator {
+  constructor(args, opts) {
+    super(args, opts);
+  }
+
+  async prompting() {
+    let prompts = [];
+    prompts.push({
+      type: "input",
+      name: "wdi5ConfPath",
+      message: "in what directory do you want the wdi5 config file to live?",
+      default: "./"
+    });
+    prompts.push({
+      type: "input",
+      name: "wdi5TestDirName",
+      message: "in what directory do the wdi5 tests live?",
+      default: "uimodule/webapp/test/wdi5"
+    });
+    prompts.push({
+      type: "input",
+      name: "baseUrl",
+      message: "URL to the app under test:",
+      default: "http://localhost:8080"
+    });
+    prompts.push({
+      type: "input",
+      name: "indexFile",
+      message: "name of the index file of the app under test:",
+      default: "index.html"
+    });
+
+    this.answers = await this.prompt(prompts);
+  }
+
+  async writing() {
+    // merging config for convenience
+    Object.assign(this.answers, this.config.getAll());
+
+    // wdi5 config file
+    this.fs.copyTpl(
+      this.templatePath("wdio-wdi5.conf.js"),
+      this.destinationPath(this.answers.wdi5ConfPath, "wdio-wdi5.conf.js"),
+      this.answers
+    );
+
+    // sample test file
+    this.fs.copyTpl(
+      this.templatePath("basic.test.js"),
+      this.destinationPath(this.answers.wdi5TestDirName, "basic.test.js"),
+      this.answers
+    );
+
+    // mingle path to where the wdi5 config file should live
+    let _configPath;
+    if (this.answers.wdi5ConfPath.endsWith("/")) {
+      _configPath = this.answers.wdi5ConfPath.slice(0, -1);
+    } else {
+      _configPath = this.answers.wdi5ConfPath;
+    }
+    this.log("[wdi5] we'll modify /package.json for you for including wdi5");
+    this.log("[wdi5] so it's safe to allow overwriting the file!");
+    await fileaccess.manipulateJSON.call(this, "/package.json", function (pkg) {
+      pkg.scripts.wdi5 = `wdio ${_configPath}/wdio-wdi5.conf.js`;
+      pkg.devDependencies["wdio-ui5-service"] = "*";
+      return pkg;
+    }.bind(this));
+
+  }
+
+  install() {
+    this.config.set("setupCompleted", true);
+    this.log("[wdi5] using wdio cli for installing required node modules...");
+    // do the wdio config boogie for defaults
+    process.chdir(this.destinationPath());
+    this.spawnCommandSync("npm", ["i", "@wdio/cli"]); // we need this as a prereq for next npx call
+    this.spawnCommandSync("npx", ["wdio", "config", "-y"]); // generate a std wdio conf for receiving npm module deps
+    // delete the shipped wdio.conf.js (from wdio defaults)
+    // as it doesn't contain wdi5
+    this.log("[wdi5] it's safe (!) to delete the default wdio.conf.js");
+    this.log(`[wdi5] a specific wdio-wdi5.conf.js is provided at ${this.answers.wdi5ConfPath} !`);
+    this.fs.delete(this.destinationPath("wdio.conf.js"));
+
+    // quicker than this.installDependencies()
+    this.spawnCommandSync("npm", ["i", "wdio-ui5-service"]);
+  }
+
+  end() {
+    this.log("[wdi5] good to go!");
+    this.log("[wdi5] 1. start the ui5 app via 'npm run start'");
+    this.log("[wdi5] 2. run wdi5 tests via 'npm run wdi5'");
+  }
+};

--- a/generators/wdi5/templates/.gitignore
+++ b/generators/wdi5/templates/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/generators/wdi5/templates/README-wdi5.md
+++ b/generators/wdi5/templates/README-wdi5.md
@@ -1,0 +1,28 @@
+## wdi5 tests
+
+Create and run tests with [wdi5](https://github.com/js-soft/wdi5)
+
+## How to run
+
+1. start the ui5 app via `npm run start`
+1. run `wdi5` via `npm run wdi5`  
+  this will start Chrome,  
+  call the ui5 app at `http://localhost:8080`  
+  and validate that the `sap.m.App` control is visible   
+
+Additional options can be triggered via `env` variables `HEADLESS` and `DEBUG`:
+
+```bash
+# starts Chrome in headles mode (think: ci/cd)
+HEADLESS=true npm run wdi5
+```
+
+```bash
+# increases timeouts and 
+# per default opens up the dev tools when Chrome is launched
+DEBUG=true npm run wdi5
+```
+
+## Credits
+
+This project has been generated with 💙 and [easy-ui5](https://github.com/SAP/generator-easy-ui5)

--- a/generators/wdi5/templates/basic.test.js
+++ b/generators/wdi5/templates/basic.test.js
@@ -1,0 +1,17 @@
+// more on wdi5, syntax, and optional page object patterns at
+// https://github.com/js-soft/wdi5
+// https://blogs.sap.com/2020/11/19/state-of-testing-in-ui5-opa5-uiveri5-and-wdi5/
+
+describe("basic wdi5 tests", () => {
+    it("should validate the running app", () => {
+        const _selector = {
+            // forceSelect: true, // only use if reselect is necessary after re-rendering of UI
+            selector: {
+                viewName: "<%= projectname ? namespace + '.' + projectname : namespace %>.<%= viewname ? 'view.' + viewname : 'view.MainView.xml' %>",
+                id: "idAppControl"
+            }
+        }
+        const App = browser.asControl(_selector)
+        expect(App.getVisible() /* UI5 Control API */).toBeTruthy()
+    })
+})

--- a/generators/wdi5/templates/wdio-wdi5.conf.js
+++ b/generators/wdi5/templates/wdio-wdi5.conf.js
@@ -1,0 +1,282 @@
+exports.config = {
+    //
+    // ====================
+    // Runner Configuration
+    // ====================
+    //
+    // WebdriverIO allows it to run your tests in arbitrary locations (e.g. locally or
+    // on a remote machine).
+    runner: "local",
+    //
+    // ==================
+    // Specify Test Files
+    // ==================
+    // Define which test specs should run. The pattern is relative to the directory
+    // from which `wdio` was called. Notice that, if you are calling `wdio` from an
+    // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
+    // directory is where your package.json resides, so `wdio` will be called from there.
+    //
+    specs: ["<%= wdi5TestDirName %>/**/*.test.js"],
+    // Patterns to exclude.
+    exclude: [
+        // 'path/to/excluded/files'
+    ],
+    //
+    // ============
+    // Capabilities
+    // ============
+    // Define your capabilities here. WebdriverIO can run multiple capabilities at the same
+    // time. Depending on the number of capabilities, WebdriverIO launches several test
+    // sessions. Within your capabilities you can overwrite the spec and exclude options in
+    // order to group specific specs to a specific capability.
+    //
+    // First, you can define how many instances should be started at the same time. Let's
+    // say you have 3 different capabilities (Chrome, Firefox, and Safari) and you have
+    // set maxInstances to 1; wdio will spawn 3 processes. Therefore, if you have 10 spec
+    // files and you set maxInstances to 10, all spec files will get tested at the same time
+    // and 30 processes will get spawned. The property handles how many capabilities
+    // from the same test should run tests.
+    //
+    maxInstances: 10,
+    //
+    // If you have trouble getting all important capabilities together, check out the
+    // Sauce Labs platform configurator - a great tool to configure your capabilities:
+    // https://docs.saucelabs.com/reference/platforms-configurator
+    //
+    capabilities: [
+        {
+            // maxInstances can get overwritten per capability. So if you have an in-house Selenium
+            // grid with only 5 firefox instances available you can make sure that not more than
+            // 5 instances get started at a time.
+            maxInstances: 5,
+            //
+            browserName: "chrome",
+            "goog:chromeOptions": {
+                w3c: false,
+                args: process.env.HEADLESS ? ["--headless"] : process.env.DEBUG ? ["window-size=1440,800", "--auto-open-devtools-for-tabs"] : ["window-size=1440,800"],
+            },
+            acceptInsecureCerts: true,
+            // If outputDir is provided WebdriverIO can capture driver session logs
+            // it is possible to configure which logTypes to include/exclude.
+            // excludeDriverLogs: ['*'], // pass '*' to exclude all driver session logs
+            // excludeDriverLogs: ['bugreport', 'server'],
+        },
+    ],
+    //
+    // ===================
+    // Test Configurations
+    // ===================
+    // Define all options that are relevant for the WebdriverIO instance here
+    //
+    // Level of logging verbosity: trace | debug | info | warn | error | silent
+    logLevel: process.env.HEADLESS ? "silent" : "info",
+    //
+    // Set specific log levels per logger
+    // loggers:
+    // - webdriver, webdriverio
+    // - @wdio/applitools-service, @wdio/browserstack-service, @wdio/devtools-service, @wdio/sauce-service
+    // - @wdio/mocha-framework, @wdio/jasmine-framework
+    // - @wdio/local-runner
+    // - @wdio/sumologic-reporter
+    // - @wdio/cli, @wdio/config, @wdio/sync, @wdio/utils
+    // Level of logging verbosity: trace | debug | info | warn | error | silent
+    // logLevels: {
+    //     webdriver: 'info',
+    //     '@wdio/applitools-service': 'info'
+    // },
+    //
+    // If you only want to run your tests until a specific amount of tests have failed use
+    // bail (default is 0 - don't bail, run all tests).
+    bail: 0,
+    //
+    // Set a base URL in order to shorten url command calls. If your `url` parameter starts
+    // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
+    // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
+    // gets prepended directly.
+    baseUrl: "<%= baseUrl %>",
+    //
+    // Default timeout for all waitFor* commands.
+    waitforTimeout: 10000,
+    //
+    // Default timeout in milliseconds for request
+    // if browser driver or grid doesn't send response
+    connectionRetryTimeout: 120000,
+    //
+    // Default request retries count
+    connectionRetryCount: 3,
+    //
+    // Test runner services
+    // Services take over a specific job you don't want to take care of. They enhance
+    // your test setup with almost no effort. Unlike plugins, they don't add new
+    // commands. Instead, they hook themselves up into the test process.
+    services: [
+        "chromedriver", // Webdriver.IO standard
+        "ui5" // this is all that's required to hook up UI5 with Webdriver.IO via wdi5 :)
+    ],
+
+    // Framework you want to run your specs with.
+    // The following are supported: Mocha, Jasmine, and Cucumber
+    // see also: https://webdriver.io/docs/frameworks.html
+    //
+    // Make sure you have the wdio adapter package for the specific framework installed
+    // before running any tests.
+    framework: "mocha",
+    //
+    // The number of times to retry the entire specfile when it fails as a whole
+    // specFileRetries: 1,
+    //
+    // Delay in seconds between the spec file retry attempts
+    // specFileRetriesDelay: 0,
+    //
+    // Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
+    // specFileRetriesDeferred: false,
+    //
+    // Test reporter for stdout.
+    // The only one supported by default is 'dot'
+    // see also: https://webdriver.io/docs/dot-reporter.html
+    reporters: ["spec"],
+
+    //
+    // Options to be passed to Mocha.
+    // See the full list at http://mochajs.org/
+    mochaOpts: {
+        ui: "bdd",
+        timeout: process.env.DEBUG ? (24 * 60 * 60 * 1000) : 60000,
+    },
+
+    wdi5: {
+        screenshotPath: require("path").join("test", "e2e-wdi5", "report", "screenshots"),
+        logLevel: process.env.HEADLESS ? "silent" : "error", // error | verbose | silent
+        platform: "browser", // browser | (android | ios | electron -> only via wdi5, not wdio-ui5-service)
+        url: "<%= indexFile %>", // path to your bootstrap html file
+        deviceType: "web", // web | (native -> only via wdi5, not wdio-ui5-service)
+    },
+    //
+    // =====
+    // Hooks
+    // =====
+    // WebdriverIO provides several hooks you can use to interfere with the test process in order to enhance
+    // it and to build services around it. You can either apply a single function or an array of
+    // methods to it. If one of them returns with a promise, WebdriverIO will wait until that promise got
+    // resolved to continue.
+    /**
+     * Gets executed once before all workers get launched.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     */
+    // onPrepare: function (config, capabilities) {
+    // },
+    /**
+     * Gets executed before a worker process is spawned and can be used to initialise specific service
+     * for that worker as well as modify runtime environments in an async fashion.
+     * @param  {String} cid      capability id (e.g 0-0)
+     * @param  {[type]} caps     object containing capabilities for session that will be spawn in the worker
+     * @param  {[type]} specs    specs to be run in the worker process
+     * @param  {[type]} args     object that will be merged with the main configuration once worker is initialised
+     * @param  {[type]} execArgv list of string arguments passed to the worker process
+     */
+    // onWorkerStart: function (cid, caps, specs, args, execArgv) {
+    // },
+    /**
+     * Gets executed just before initialising the webdriver session and test framework. It allows you
+     * to manipulate configurations depending on the capability or spec.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
+    // beforeSession: function (config, capabilities, specs) {
+    // },
+    /**
+     * Gets executed before test execution begins. At this point you can access to all global
+     * variables like `browser`. It is the perfect place to define custom commands.
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that are to be run
+     */
+    // before: function (capabilities, specs) {
+    // },
+    /**
+     * Runs before a WebdriverIO command gets executed.
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     */
+    // beforeCommand: function (commandName, args) {
+    // },
+    /**
+     * Hook that gets executed before the suite starts
+     * @param {Object} suite suite details
+     */
+    // beforeSuite: function (suite) {
+    // },
+    /**
+     * Function to be executed before a test (in Mocha/Jasmine) starts.
+     */
+    // beforeTest: function (test, context) {
+    // },
+    /**
+     * Hook that gets executed _before_ a hook within the suite starts (e.g. runs before calling
+     * beforeEach in Mocha)
+     */
+    // beforeHook: function (test, context) {
+    // },
+    /**
+     * Hook that gets executed _after_ a hook within the suite starts (e.g. runs after calling
+     * afterEach in Mocha)
+     */
+    // afterHook: function (test, context, { error, result, duration, passed, retries }) {
+    // },
+    /**
+     * Function to be executed after a test (in Mocha/Jasmine).
+     */
+    // afterTest: function(test, context, { error, result, duration, passed, retries }) {
+    // },
+
+    /**
+     * Hook that gets executed after the suite has ended
+     * @param {Object} suite suite details
+     */
+    // afterSuite: function (suite) {
+    // },
+    /**
+     * Runs after a WebdriverIO command gets executed
+     * @param {String} commandName hook command name
+     * @param {Array} args arguments that command would receive
+     * @param {Number} result 0 - command success, 1 - command error
+     * @param {Object} error error object if any
+     */
+    // afterCommand: function (commandName, args, result, error) {
+    // },
+    /**
+     * Gets executed after all tests are done. You still have access to all global variables from
+     * the test.
+     * @param {Number} result 0 - test pass, 1 - test fail
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that ran
+     */
+    // after: function (result, capabilities, specs) {
+    // },
+    /**
+     * Gets executed right after terminating the webdriver session.
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {Array.<String>} specs List of spec file paths that ran
+     */
+    // afterSession: function (config, capabilities, specs) {
+    // },
+    /**
+     * Gets executed after all workers got shut down and the process is about to exit. An error
+     * thrown in the onComplete hook will result in the test run failing.
+     * @param {Object} exitCode 0 - success, 1 - fail
+     * @param {Object} config wdio configuration object
+     * @param {Array.<Object>} capabilities list of capabilities details
+     * @param {<Object>} results object containing test results
+     */
+    // onComplete: function(exitCode, config, capabilities, results) {
+    // },
+    /**
+     * Gets executed when a refresh happens.
+     * @param {String} oldSessionId session ID of the old session
+     * @param {String} newSessionId session ID of the new session
+     */
+    //onReload: function(oldSessionId, newSessionId) {
+    //}
+};


### PR DESCRIPTION
this PR adds support for `wdi5` as a test framework, via `yo easy-ui5:wdi5`,   
targeted at ui5 stand-alone apps.

it holds a default config, a sample test file and compact documentation on how to use wdi5.  
some convenience env vars are already respected at `wdi5`-test-time, as denoted in the `README`.