### PR TITLE
fix: use the org name of the selected generator for repo download

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -357,7 +357,7 @@ module.exports = class extends Generator {
         }
         this._showBusy(`  Downloading and extracting "${generator.name}" templates`);
         const reqZIPArchive = await octokit.repos.downloadZipballArchive({
-          owner: this.options.ghOrg,
+          owner: generator.org,
           repo: generator.name,
           ref: commitSHA,
         });


### PR DESCRIPTION
Hi @petermuessig & @nicogeburek,
when downloading the repo of the selected generator we've used the org specified in the parameter ghOrg (default ui5-community) so far. That's why my test's and probably your tests with forked ui5-community repos worked. But the download of generators not available in the community org will always fail. 
  

