### PR TITLE
fix(postinstall): avoid non-existing node_modules

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -7,7 +7,7 @@ const { hasYarn } = require("yarn-or-npm");
 
 const path = require("path");
 const fs = require("fs");
-const { rmdir } = require("fs").promises;
+const { rm } = require("fs").promises;
 
 const { Octokit } = require("@octokit/rest");
 const { throttling } = require("@octokit/plugin-throttling");
@@ -346,7 +346,7 @@ module.exports = class extends Generator {
           }
           // remove if the SHA marker doesn't exist => outdated!
           this._showBusy(`  Removing old "${generator.name}" templates`);
-          await rmdir(generatorPath, { recursive: true });
+          await rm(generatorPath, { recursive: true });
         }
       }
 
@@ -385,7 +385,7 @@ module.exports = class extends Generator {
         }
         this._showBusy(`  Preparing "${generator.name}"`);
         await new Promise(function (resolve, reject) {
-          spawn((hasYarn() ? "yarn" : "npm"), ["install", "--no-progress"], {
+          spawn((hasYarn() ? "yarn" : "npm"), ["install", "--no-progress", "--ignore-engines"], {
             stdio: this.config.verbose ? "inherit" : "ignore",
             cwd: generatorPath,
             env: {

--- a/generators/app/postinstall.js
+++ b/generators/app/postinstall.js
@@ -1,7 +1,7 @@
 "use strict";
 const spawn = require("cross-spawn");
 const fs = require("fs");
-const { rmdir } = require("fs").promises;
+const { rm } = require("fs").promises;
 const path = require("path");
 const { hasYarn } = require("yarn-or-npm");
 const { Octokit } = require("@octokit/rest");
@@ -66,7 +66,7 @@ const ghOrg = "ui5-community",
       console.log("The default generator is outdated...");
       // remove if the SHA marker doesn't exist => outdated!
       showBusy("  Removing old default templates");
-      await rmdir(generatorPath, { recursive: true });
+      await rm(generatorPath, { recursive: true });
     }
   }
 
@@ -102,7 +102,7 @@ const ghOrg = "ui5-community",
     console.log("Installing the plugin dependencies...");
     showBusy("  Preparing the default templates");
     await new Promise(function (resolve, reject) {
-      spawn((hasYarn() ? "yarn" : "npm"), ["install", "--no-progress"], {
+      spawn((hasYarn() ? "yarn" : "npm"), ["install", "--no-progress", "--ignore-engines"], {
         stdio: "inherit",
         cwd: generatorPath,
         env: {


### PR DESCRIPTION
In case of incompatible engines when using `yarn` as NPM client, it could be that the `yarn install` doesn't work. Therefore, we add the command line option `--ignore-engines` to the `yarn` and `npm` execution which will run the `install` command regardless of the engine version.
