### PR TITLE
fix: drop --prefer-offline and migrate list prompt to select

### DIFF
--- a/.changeset/fix-npm-install-and-list-prompt.md
+++ b/.changeset/fix-npm-install-and-list-prompt.md
@@ -1,0 +1,8 @@
+---
+"generator-easy-ui5": patch
+---
+
+Fix scaffolding interactive flow:
+
+- Drop `--prefer-offline` from the internal `npm install` invocation; the flag could prevent the install from completing properly when the offline cache is incomplete or stale.
+- Replace the deprecated inquirer `list` prompt type with `select` for the generator and sub-generator selection prompts.

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -68,7 +68,7 @@ export default class EasyUI5Generator extends Generator {
 			// `(command, execaOptions)` (no args array — it parses the shell
 			// string), whereas `spawn` takes `(command, args[], options)`. We
 			// pass argv as an array, so we want `spawn`.
-			this.spawn("npm", ["install", "--no-progress", "--ignore-engines", "--ignore-scripts", "--prefer-offline"], {
+			this.spawn("npm", ["install", "--no-progress", "--ignore-engines", "--ignore-scripts"], {
 				stdio: this.config.verbose ? "inherit" : "ignore",
 				cwd: dir,
 				env: {
@@ -496,7 +496,7 @@ export default class EasyUI5Generator extends Generator {
 				const generatorIdx = (
 					await this.prompt([
 						{
-							type: "list",
+							type: "select",
 							name: "generator",
 							message: "Select your generator?",
 							choices: availGenerators.map((availGenerator, idx) => ({
@@ -617,7 +617,7 @@ export default class EasyUI5Generator extends Generator {
 					subGenerator = (
 						await this.prompt([
 							{
-								type: "list",
+								type: "select",
 								name: "subGenerator",
 								message: "What do you want to do?",
 								default: defaultSubGenerator && defaultSubGenerator.value,


### PR DESCRIPTION
## Changes

- **Remove `--prefer-offline`** from the `npm install` invocation in [generators/app/index.js](generators/app/index.js#L71). This flag could prevent `npm install` from completing properly when the offline cache is incomplete or stale.
- **Migrate deprecated `list` prompt to `select`** in [generators/app/index.js](generators/app/index.js#L499) and [generators/app/index.js#L620](generators/app/index.js#L620). Inquirer's `list` prompt type is deprecated in favor of `select`.

## Why

Both issues surface in the interactive flow of the root generator and prevent / warn during normal scaffolding. This is a low-risk patch fix.
