### PR TITLE
feat!: Node.js 22.13 baseline + Dependabot rollup

### DIFF
--- a/.changeset/node-22-baseline.md
+++ b/.changeset/node-22-baseline.md
@@ -1,0 +1,18 @@
+---
+"generator-easy-ui5": minor
+---
+
+Require Node.js 22.13 or higher
+
+The minimum supported Node.js version is now `>=22.13` (previously `>=20.19`).
+Node 20 has moved out of Active LTS and the UI5 ecosystem is standardising on
+Node 22 as the common floor; the exact `22.13` threshold matches the range
+already required by our transitive dependencies (yeoman-generator, glob, and
+others).
+
+- CI now tests on Node **22, 24, and 26**.
+- `lint-staged` bumped to 17 (drops Node 20 support).
+- `@commitlint/cli` and `@commitlint/config-conventional` bumped to 21.
+- `globals` bumped to 17.7.
+- Pinned GitHub Action SHAs refreshed (`actions/checkout` v7,
+  `actions/setup-node` v6, `changesets/action` v1.9, `softprops/action-gh-release` v3).

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -24,12 +24,12 @@ jobs:
     if: github.head_ref != 'changeset-release/main'
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,12 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
@@ -68,7 +68,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: npm run version-packages
           publish: npm run release-publish
@@ -81,7 +81,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: v${{ fromJSON(steps.changesets.outputs.publishedPackages)[0].version }}
           generate_release_notes: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         version: [20, 22, 24]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.version }}
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [20, 22, 24]
+        version: [22, 24, 26]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Note that the developers also have their regular duties, so depending on the req
 
 ## Local development
 
-Requires Node.js `>=20.19` (matches `engines.node` in `package.json`).
+Requires Node.js `>=22.13` (matches `engines.node` in `package.json`).
 
 ### Useful scripts
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The purpose of the (preinstalled) `project generator` is to guide you on your fi
 
 ## Requirements
 
-- Get [Node.js](https://nodejs.org/en/download/) (:warning: **version 20.19 or higher**).
+- Get [Node.js](https://nodejs.org/en/download/) (:warning: **version 22.13 or higher**).
 
 ## Download and Installation
 

--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ Please follow our instructions if you would like to [contribute](https://github.
 
 [npm-image]: https://img.shields.io/npm/v/generator-easy-ui5.svg
 [npm-url]: https://www.npmjs.com/package/generator-easy-ui5
-[test-image]: https://github.com/ui5-community/generator-easy-ui5/actions/workflows/main.yml/badge.svg
-[test-url]: https://github.com/ui5-community/generator-easy-ui5/actions/workflows/main.yml
+[test-image]: https://github.com/ui5-community/generator-easy-ui5/actions/workflows/release.yml/badge.svg
+[test-url]: https://github.com/ui5-community/generator-easy-ui5/actions/workflows/release.yml
 [librariesio-image]: https://img.shields.io/librariesio/github/ui5-community/generator-easy-ui5
 [repo-url]: https://github.com/ui5-community/generator-easy-ui5
 [license-image]: https://img.shields.io/npm/l/generator-easy-ui5.svg

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,15 +70,7 @@ export default [
 			"n/no-extraneous-require": 2,
 			"n/no-missing-import": 2,
 			// We rely on engines.node — let n verify our usage matches.
-			"n/no-unsupported-features/node-builtins": [
-				2,
-				{
-					// `fs.cpSync` is functional since Node 16.7 and only lost
-					// its "experimental" label in Node 22.3 — it works fine on
-					// our engines.node floor (20.19). Ignore it explicitly.
-					ignores: ["fs.cpSync"],
-				},
-			],
+			"n/no-unsupported-features/node-builtins": 2,
 			// hoist-non-react-statics-style: not all CommonJS interop matters here
 			"n/no-unpublished-import": 0,
 			"n/no-unpublished-require": 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "eslint-plugin-n": "18.1.0",
         "eslint-plugin-security": "4.0.1",
         "fs-extra": "11.3.5",
-        "globals": "17.6.0",
+        "globals": "17.7.0",
         "husky": "9.1.7",
         "lint-staged": "16.4.0",
         "lockfile-lint": "5.0.0",
@@ -4661,9 +4661,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
       "devDependencies": {
         "@changesets/changelog-github": "0.7.0",
         "@changesets/cli": "2.31.0",
-        "@commitlint/cli": "20.2.0",
-        "@commitlint/config-conventional": "20.2.0",
+        "@commitlint/cli": "21.1.0",
+        "@commitlint/config-conventional": "21.1.0",
         "@eslint/js": "10.0.1",
         "eslint": "10.5.0",
         "eslint-plugin-n": "18.1.0",
@@ -629,134 +629,203 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.2.0.tgz",
-      "integrity": "sha512-l37HkrPZ2DZy26rKiTUvdq/LZtlMcxz+PeLv9dzK9NzoFGuJdOQyYU7IEkEQj0pO++uYue89wzOpZ0hcTtoqUA==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.1.0.tgz",
+      "integrity": "sha512-CVwY6TxGv5naEaWxBdgNHko1xgL95Mb4WcIqp9iik33H0ctVqRv6YtekCntayhEP0T/apuiGvHu5HcCwFuVxEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/format": "^20.2.0",
-        "@commitlint/lint": "^20.2.0",
-        "@commitlint/load": "^20.2.0",
-        "@commitlint/read": "^20.2.0",
-        "@commitlint/types": "^20.2.0",
+        "@commitlint/config-conventional": "^21.1.0",
+        "@commitlint/format": "^21.1.0",
+        "@commitlint/lint": "^21.1.0",
+        "@commitlint/load": "^21.1.0",
+        "@commitlint/read": "^21.1.0",
+        "@commitlint/types": "^21.1.0",
         "tinyexec": "^1.0.0",
-        "yargs": "^17.0.0"
+        "yargs": "^18.0.0"
       },
       "bin": {
         "commitlint": "cli.js"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@commitlint/cli/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.2.0.tgz",
-      "integrity": "sha512-MsRac+yNIbTB4Q/psstKK4/ciVzACHicSwz+04Sxve+4DW+PiJeTjU0JnS4m/oOnulrXYN+yBPlKaBSGemRfgQ==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.1.0.tgz",
+      "integrity": "sha512-BIFl8xM+3SLy3jrblUC3wmQLCVbLty+++6o859BDCmybVrQdXmIWO+dlkGIbv/M2bBoC55wGuh0zGiw3TPjL1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.2.0",
-        "conventional-changelog-conventionalcommits": "^7.0.2"
+        "@commitlint/types": "^21.1.0",
+        "conventional-changelog-conventionalcommits": "^9.2.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.5.0.tgz",
-      "integrity": "sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.1.0.tgz",
+      "integrity": "sha512-gHczt1xqQSwfNqBmOI3HjejtTljkiBEUneExMmTBLD0WwTC78lAqDvNMyydbySt3DhpH0F9oX7Vvuks6s5XPFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/types": "^21.1.0",
         "ajv": "^8.11.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "20.5.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.3.tgz",
-      "integrity": "sha512-4i4AgNvH62owG9MwSiWKrle7HGNpBHHdLnWFIp5fTsHUYe5kRuh15t08L/0pdbbrRk8JKXQxxN4hZQcn+szkrw==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.1.0.tgz",
+      "integrity": "sha512-/S8Mo3Q1NtQUYDQjDmyQVPxfIwtnxq+guzMOkuGk8OSdwlzanm1WB9wDPIuuzlbMDDnBNbiAuBEUCcCNlfjrTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/types": "^21.1.0",
         "es-toolkit": "^1.46.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/execute-rule": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-20.0.0.tgz",
-      "integrity": "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.1.tgz",
+      "integrity": "sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.5.0.tgz",
-      "integrity": "sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.1.0.tgz",
+      "integrity": "sha512-ySymqKYBfjNrQ5N4W/l1iF2ISW1W7Eu/Oi/wRxlri31N0yjNyzUyUzQwyuZLDzTXIlMs4IZ7hIOfAZx8lO18gA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/types": "^21.1.0",
         "picocolors": "^1.1.1"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.5.0.tgz",
-      "integrity": "sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.1.0.tgz",
+      "integrity": "sha512-RoRh1/YI+fYH+aid5lMQ2UD0vZ3p3Vf1KeUWT1ir3H/p/7T/6SFv1OiXLgLwUT8dP72EVWeEIyOfkiSWLZYVvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/types": "^21.1.0",
         "semver": "^7.6.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "20.5.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.3.tgz",
-      "integrity": "sha512-M7JbWBNr2gXKaPc4i/KipsuW1gkDHpj35KPjWtKy3Z+2AQw5wu1gBi1LIO0uoaij67CqY4K8PxPZSGens4evCw==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.1.0.tgz",
+      "integrity": "sha512-0DbfVVUjAWBfixW6v7CXXWVxMcj6Ukf/oB7O8NAbouP3jxmqUaC4eVQphxl3B3M0ii3cCQiR3sRAYxICwU2gAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/is-ignored": "^20.5.0",
-        "@commitlint/parse": "^20.5.0",
-        "@commitlint/rules": "^20.5.3",
-        "@commitlint/types": "^20.5.0"
+        "@commitlint/is-ignored": "^21.1.0",
+        "@commitlint/parse": "^21.1.0",
+        "@commitlint/rules": "^21.1.0",
+        "@commitlint/types": "^21.1.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "20.5.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.3.tgz",
-      "integrity": "sha512-1FDZWuKyu98Myb8i7Tp31jPU2rZpOwAdYRyJcy2KoGg7Xk2A+bgHN8smhMaaNSNkmE8fwt53BokywZq8Gv/5XQ==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.1.0.tgz",
+      "integrity": "sha512-juiClVEcoreNB0TNVkseO2EmNcpEs/Yhnmgbnm/hQAKBFRynKwIaoNIljXkx/3yvZcMO0EE8I2XOEI7d5KZG8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^20.5.0",
-        "@commitlint/execute-rule": "^20.0.0",
-        "@commitlint/resolve-extends": "^20.5.3",
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/config-validator": "^21.1.0",
+        "@commitlint/execute-rule": "^21.0.1",
+        "@commitlint/resolve-extends": "^21.1.0",
+        "@commitlint/types": "^21.1.0",
         "cosmiconfig": "^9.0.1",
         "cosmiconfig-typescript-loader": "^6.1.0",
         "es-toolkit": "^1.46.0",
@@ -764,112 +833,110 @@
         "picocolors": "^1.1.1"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "20.4.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.4.3.tgz",
-      "integrity": "sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.0.2.tgz",
+      "integrity": "sha512-5n4aqHGD/FNnom/D5L8i7cYtV+xjuXcBL832C3w9VglEsZzIsoHpJsvxzJ7cgiOsOdc/2jU4t5+7qMHh7GBX3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.5.0.tgz",
-      "integrity": "sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.1.0.tgz",
+      "integrity": "sha512-HdAqbbjQS8eEtbR74Ysg2VNmbvAfeWLVYMkip/lHibNrtjRsC/97XAYN3/H5P0pEJtDfyTb3iLs8x6y0eu4OYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/types": "^21.1.0",
         "conventional-changelog-angular": "^8.2.0",
         "conventional-commits-parser": "^6.3.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.5.0.tgz",
-      "integrity": "sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.1.0.tgz",
+      "integrity": "sha512-ID7m79aw8d0dMlxuXHD2QGxEX3Fhl/mUPA80WwEW5VgeOpUHNahhwWJefDdoBDVZcDfbHuf429NrcK0gxQsQjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/top-level": "^20.4.3",
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/top-level": "^21.0.2",
+        "@commitlint/types": "^21.1.0",
         "git-raw-commits": "^5.0.0",
-        "minimist": "^1.2.8",
         "tinyexec": "^1.0.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "20.5.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.3.tgz",
-      "integrity": "sha512-+ogW9v/u9JqpvAgTrLra/YTFo0KkjU6iNblF89pPsj4NebNc+DAWctsludwezI8YnsjBmfHpApSwcXprN/f/ew==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.1.0.tgz",
+      "integrity": "sha512-SANYkxJDfMl3TvnyALWHEaiF5nc6FFaOnh7VvfxjT4X2vD4i2gVHhmfMm1fsrBwDRX98/XyM1XDo5sAd/KXcyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^20.5.0",
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/config-validator": "^21.1.0",
+        "@commitlint/types": "^21.1.0",
         "es-toolkit": "^1.46.0",
         "global-directory": "^5.0.0",
-        "import-meta-resolve": "^4.0.0",
         "resolve-from": "^5.0.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "20.5.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.3.tgz",
-      "integrity": "sha512-MPlMnb9D3wbszYMp+1hPtuhtPJndRo6I6yfkZVA4+jR8w7Kqp0u2u/Y+gzbaItx5Lltq5rw7FSZQWJMoXUC4NQ==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.1.0.tgz",
+      "integrity": "sha512-fOPEYSmKn1ZJptjLmCEjJfYqz0PUYr8ng6VY2ZW26sB7KtENR90CmAXHEmScBbOIZip+d/+OwqK12DFBuHTqsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/ensure": "^20.5.3",
-        "@commitlint/message": "^20.4.3",
-        "@commitlint/to-lines": "^20.0.0",
-        "@commitlint/types": "^20.5.0"
+        "@commitlint/ensure": "^21.1.0",
+        "@commitlint/message": "^21.0.2",
+        "@commitlint/to-lines": "^21.0.1",
+        "@commitlint/types": "^21.1.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/to-lines": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-20.0.0.tgz",
-      "integrity": "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.1.tgz",
+      "integrity": "sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "20.4.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.4.3.tgz",
-      "integrity": "sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==",
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.0.2.tgz",
+      "integrity": "sha512-s9KKM+e+mXgFeIh4n7KmOGAVT3mkJ3Fp1bBYHIK5pjeUwlEMzp/tZfb5u0Poa680AsQTXMEMRxZi1vQ9m2X5ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.5.0.tgz",
-      "integrity": "sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.1.0.tgz",
+      "integrity": "sha512-YodnnnH1Cp+08nP8HGNJAIuB6L3/vdCTHVRTfF8Ik/wRCLOTsU9zwv3yO1cSPQRDa9CLYtE+UJ2K67r7CwMSFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -877,7 +944,7 @@
         "picocolors": "^1.1.1"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@conventional-changelog/git-client": {
@@ -3483,16 +3550,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-commits-parser": {
@@ -4601,6 +4668,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-5.0.1.tgz",
       "integrity": "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==",
+      "deprecated": "Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4898,17 +4966,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "fs-extra": "11.3.5",
         "globals": "17.7.0",
         "husky": "9.1.7",
-        "lint-staged": "16.4.0",
+        "lint-staged": "17.0.8",
         "lockfile-lint": "5.0.0",
         "mocha": "11.7.6",
         "prettier": "3.8.4",
@@ -42,7 +42,7 @@
         "yosay": "3.0.0"
       },
       "engines": {
-        "node": ">=20.19"
+        "node": ">=22.13"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3456,13 +3456,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/colors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
@@ -5394,45 +5387,63 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
-      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.8.tgz",
+      "integrity": "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.3",
-        "listr2": "^9.0.5",
-        "picomatch": "^4.0.3",
+        "listr2": "^10.2.1",
+        "picomatch": "^4.0.4",
         "string-argv": "^0.3.2",
-        "tinyexec": "^1.0.4",
-        "yaml": "^2.8.2"
+        "tinyexec": "^1.2.4"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
       },
       "engines": {
-        "node": ">=20.17"
+        "node": ">=22.22.1"
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/listr2": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
-      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
+      "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cli-truncate": "^5.0.0",
-        "colorette": "^2.0.20",
-        "eventemitter3": "^5.0.1",
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
         "log-update": "^6.1.0",
         "rfdc": "^1.4.1",
-        "wrap-ansi": "^9.0.0"
+        "wrap-ansi": "^10.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/locate-path": {
@@ -8393,6 +8404,7 @@
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "plugins"
   ],
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22.13"
   },
   "scripts": {
     "embed": "npx yo@7.0.1 ./generators/app/index.js project --embed",
@@ -77,7 +77,7 @@
     "fs-extra": "11.3.5",
     "globals": "17.7.0",
     "husky": "9.1.7",
-    "lint-staged": "16.4.0",
+    "lint-staged": "17.0.8",
     "lockfile-lint": "5.0.0",
     "mocha": "11.7.6",
     "prettier": "3.8.4",

--- a/package.json
+++ b/package.json
@@ -68,8 +68,8 @@
   "devDependencies": {
     "@changesets/changelog-github": "0.7.0",
     "@changesets/cli": "2.31.0",
-    "@commitlint/cli": "20.2.0",
-    "@commitlint/config-conventional": "20.2.0",
+    "@commitlint/cli": "21.1.0",
+    "@commitlint/config-conventional": "21.1.0",
     "@eslint/js": "10.0.1",
     "eslint": "10.5.0",
     "eslint-plugin-n": "18.1.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eslint-plugin-n": "18.1.0",
     "eslint-plugin-security": "4.0.1",
     "fs-extra": "11.3.5",
-    "globals": "17.6.0",
+    "globals": "17.7.0",
     "husky": "9.1.7",
     "lint-staged": "16.4.0",
     "lockfile-lint": "5.0.0",


### PR DESCRIPTION
## What

Two things bundled for **v3.11.0**:

1. **Raise the Node.js floor to `>=22.13`.** Node 20 is out of Active LTS
   and the UI5 ecosystem is standardising on Node 22. `22.13` matches the
   range already required by our transitive dependencies
   (`yeoman-generator`, `glob`, …) and lets us drop the `fs.cpSync`
   ESLint exception (stable from 22.3).
2. **Roll up every open Dependabot PR** into topically-clean commits so
   the release notes tell one coherent story instead of ten.

## Commits

| # | Commit | Rolls up |
|---|---|---|
| 1 | `chore(deps-dev): bump globals from 17.6.0 to 17.7.0` | #173 |
| 2 | `chore(deps-dev): bump commitlint to 21.1.0` | #175, #179 |
| 3 | `ci: bump pinned action SHAs` | #155, #156, #167, #180 |
| 4 | `feat!: require Node.js 22.13 or higher` | #166 (lint-staged 17) |

Two other open Dependabot PRs — #127 (`semver` 5.7.1→5.7.2) and #128
(`word-wrap` 1.2.3→1.2.4) — target versions the lockfile already exceeds
(semver 7.8.5, word-wrap 1.2.5), so no separate commit is required. They
should close automatically once this merges; if not, they can be closed
by hand.

## CI changes

- `validate.yml` matrix is now `[22, 24, 26]` (drops Node 20, adds Node 26).
- Release workflow already runs on Node 24 — unchanged.

## Verification

- `npm ci --ignore-scripts && npm test` — full mocha suite green on
  Node 22 locally.
- `npm run lint:ci` — no new errors introduced (21 pre-existing security-plugin
  warnings unchanged).
- `npx changeset status --since=origin/main` — bumps
  `generator-easy-ui5` at **minor**.

## Follow-up

Once merged, the Release workflow opens the `Version Packages` PR that
bumps to **3.11.0** and rewrites `CHANGELOG.md` from the changeset.
